### PR TITLE
export Response also like Request 

### DIFF
--- a/mod.ts
+++ b/mod.ts
@@ -182,7 +182,7 @@ export class Request {
     }
 }
 
-class Response {
+export class Response {
     status = 200;
     headers = new Headers();
     body?: string | Uint8Array | Reader;


### PR DESCRIPTION
It seems Request already export in mod.ts but if I want to code the EndHandler import from other file with typing, there should also export Response too, then we can do like this:
Handler File:
```typescript 
import * as expressive from "https://raw.githubusercontent.com/NMathar/deno-express/master/mod.ts";
export const  MainRoute  = async(req:expressive.Request, res):Promise<void>=>{
    // do some magic 
}
```
Server File:
```typescript 
 
import * as expressive from "https://raw.githubusercontent.com/NMathar/deno-express/master/mod.ts";
import { MainRoute } from "./routes/main/main.ts";

(async () => {
  const port = 3000;
  const app = new expressive.App();
  app.use(expressive.simpleLog());
  app.use(expressive.static_("./public"));
  app.use(expressive.bodyParser.json());
  app.get('/main', MainRoute);
  const server = await app.listen(port);
  console.log("app listening on port " + server.port);
})();
```

Without typing error.